### PR TITLE
Fix for readr 1.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     gridExtra,
     ggplot2,
     magrittr,
-    readr,
+    readr (>= 1.2.0),
     rmarkdown(>= 1.4),
     rvest,
     tibble,
@@ -50,3 +50,5 @@ Collate:
     'qc_read_collection.R'
     'qc_report.R'
     'qc_unzip.R'
+Remotes:
+  tidyverse/readr

--- a/R/qc_read.R
+++ b/R/qc_read.R
@@ -100,7 +100,7 @@ qc_read <- function(file, modules = "all", verbose = TRUE){
   res <- lapply(modules,
                 function(module, all.data){
                   index <- grep(module, all.data, ignore.case = TRUE)
-                  skip <- ifelse(module == "Sequence Duplication Levels", 3, 2)
+                  skip <- ifelse(module == "Sequence Duplication Levels", 2, 1)
                   if(length(index) >0) readr::read_tsv(all.data[index[1]], skip = skip)
                   else tibble::tibble()
                 },
@@ -110,7 +110,7 @@ qc_read <- function(file, modules = "all", verbose = TRUE){
   if("Sequence Duplication Levels" %in% modules){
     index <- grep("Sequence Duplication Levels", all.data, ignore.case = TRUE)
     if(length(index) >0)
-      res$total_deduplicated_percentage <- readr::read_tsv(all.data[index[1]], skip = 2, n_max = 0)%>%
+      res$total_deduplicated_percentage <- readr::read_tsv(all.data[index[1]], skip = 1, n_max = 0) %>%
         colnames(.) %>%
         .[2] %>%
         as.numeric() %>%


### PR DESCRIPTION
readr 1.2.0 automatically skips blank lines, so they are no longer
included in the count of the `skip` parameter. Unfortunately this broke
fastqcr.

readr 1.2.0 will be submitted to CRAN soon, once it is these changes will fix fastqcr to work with the new readr version. Once readr is on CRAN you can remove the `Remotes:` lines in the `DESCRIPTION`.
 
Sorry for the breakage!