### PR TITLE
Revert "Fix for readr 1.2.0"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     gridExtra,
     ggplot2,
     magrittr,
-    readr (>= 1.2.0),
+    readr (>= 1.3.0),
     rmarkdown(>= 1.4),
     rvest,
     tibble,

--- a/R/qc_read.R
+++ b/R/qc_read.R
@@ -100,7 +100,7 @@ qc_read <- function(file, modules = "all", verbose = TRUE){
   res <- lapply(modules,
                 function(module, all.data){
                   index <- grep(module, all.data, ignore.case = TRUE)
-                  skip <- ifelse(module == "Sequence Duplication Levels", 2, 1)
+                  skip <- ifelse(module == "Sequence Duplication Levels", 3, 2)
                   if(length(index) >0) readr::read_tsv(all.data[index[1]], skip = skip)
                   else tibble::tibble()
                 },
@@ -110,7 +110,7 @@ qc_read <- function(file, modules = "all", verbose = TRUE){
   if("Sequence Duplication Levels" %in% modules){
     index <- grep("Sequence Duplication Levels", all.data, ignore.case = TRUE)
     if(length(index) >0)
-      res$total_deduplicated_percentage <- readr::read_tsv(all.data[index[1]], skip = 1, n_max = 0) %>%
+      res$total_deduplicated_percentage <- readr::read_tsv(all.data[index[1]], skip = 2, n_max = 0)%>%
         colnames(.) %>%
         .[2] %>%
         as.numeric() %>%


### PR DESCRIPTION
This reverts commit bb62e34b59039010edf2027aadcbe166b109b10d.

readr 1.3.0 changes the skip line behavior to match that of readr 1.1.1,
the change in 1.2.0 was determined to be too disruptive.

Apologies for (another) breaking change, doing so was definitely not our intent!