### PR TITLE
Remove extra args in `left_join()`

### DIFF
--- a/R/qc_aggregate.R
+++ b/R/qc_aggregate.R
@@ -117,12 +117,12 @@ summary.qc_aggregate <- function(object, ...){
   failed <- qc_fails(object, element = "module") %>%
     select(module, sample) %>%
     dplyr::rename(failed = sample)
-  if(nrow(failed) >0) res <- left_join(res, failed, by = "module", fill = "---")
+  if(nrow(failed) >0) res <- left_join(res, failed, by = "module")
   # Add sample names that warn
   warned <- qc_warns(object, element = "module") %>%
     select(module, sample) %>%
     dplyr::rename(warned = sample)
-  if(nrow(warned) >0) res <- left_join(res, warned, by = "module", fill = "---")
+  if(nrow(warned) >0) res <- left_join(res, warned, by = "module")
   res
 }
 


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

`left_join()` now catches extra args passed through `...` to avoid typos. You were passing `fill =` through to `left_join()` but that argument doesn't exist.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!